### PR TITLE
Add -std=c++11 to CXXFLAGS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -46,7 +46,7 @@ LIBSTDCXX_INCLUDES  = @LIBSTDCXX_INCLUDES@
 LIBSTDCXX_LIBS      = @LIBSTDCXX_LIBS@
 AUTO_PTR_BROKEN     = @AUTO_PTR_BROKEN@
 MAKEDEPEND_INCLUDES = @MAKEDEPEND_INCLUDES@
-CXXFLAGS            = -g -O2 -Wall -Wextra @CXXFLAGS@ # automake like + warnings
+CXXFLAGS            = -g -O2 -Wall -Wextra -std=c++11 @CXXFLAGS@ # automake like + warnings
 LDFLAGS             = @LDFLAGS@
 
 INCLUDES    = $(LIBSTDCXX_INCLUDES)


### PR DESCRIPTION
Fixes build failure with earlier compilers that default to an earlier C++ standard:

```
In file included from Area.cpp:38:
In file included from ./Area.h:44:
./istr.h:29:10: error: expected expression
                        elems({})
                              ^
./istr.h:33:10: error: expected expression
                        elems({})
                              ^
./istr.h:39:10: error: expected expression
                        elems({})
                              ^
./istr.h:122:22: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
                        for (const char c : p)
                                          ^
./istr.h:166:15: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
                        for (int c : elems) {
                                   ^
2 warnings and 3 errors generated.
```

```
In file included from HTMLDriver.cpp:14:
In file included from ./HTMLDriver.h:17:
HTMLParser.yy:70:24: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<Element>>            *element_list;
                       ^~
                       > >
HTMLParser.yy:75:25: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<TableRow>>           *table_rows;
                        ^~
                        > >
HTMLParser.yy:76:26: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<TableCell>>          *table_cells;
                         ^~
                         > >
HTMLParser.yy:78:25: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<ListItem>>           *list_items;
                        ^~
                        > >
HTMLParser.yy:81:23: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<Option>>             *option_list;
                      ^~
                      > >
HTMLParser.yy:84:35: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<DefinitionListItem>> *definition_list_item_list;
                                  ^~
                                  > >
HTMLParser.yy:89:34: error: a space is required between consecutive right angle brackets (use '> >')
  list<auto_ptr<list<TagAttribute>>> *tag_attributes_list;
                                 ^~
                                 > >
In file included from HTMLDriver.cpp:14:
./HTMLDriver.h:35:20: warning: in-class initialization of non-static data member is a C++11 extension [-Wc++11-extensions]
                int list_nesting = 0;
                                 ^
./HTMLDriver.h:37:22: warning: in-class initialization of non-static data member is a C++11 extension [-Wc++11-extensions]
                OrderedList *links = nullptr;
                                   ^
./HTMLDriver.h:50:48: warning: in-class initialization of non-static data member is a C++11 extension [-Wc++11-extensions]
                html2text::HTMLParser::semantic_type *yylval = nullptr;
                                                             ^
HTMLDriver.cpp:33:47: error: a space is required between consecutive right angle brackets (use '> >')
        links->items.reset(new list<auto_ptr<ListItem>>);
                                                     ^~
                                                     > >
HTMLDriver.cpp:58:25: error: a space is required between consecutive right angle brackets (use '> >')
                        list<auto_ptr<Element>> *data = new list<auto_ptr<Element>>;
                                             ^~
                                             > >
HTMLDriver.cpp:58:61: error: a space is required between consecutive right angle brackets (use '> >')
                        list<auto_ptr<Element>> *data = new list<auto_ptr<Element>>;
                                                                                 ^~
                                                                                 > >
5 warnings and 13 errors generated.```
