### PR TITLE
Let PREFIX, BINDIR, etc. be set at configure time

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,10 +32,10 @@ BISON  = bison
 YFLAGS =
 
 INSTALLER = install
-PREFIX    = /usr/local
-BINDIR    = $(PREFIX)/bin
-MANDIR    = $(PREFIX)/share/man
-DOCDIR    = $(PREFIX)/share/doc/html2text
+PREFIX    = @PREFIX@
+BINDIR    = @BINDIR@
+MANDIR    = @MANDIR@
+DOCDIR    = @DOCDIR@
 
 CXX                 = @CXX@
 BOOL_DEFINITION     = @BOOL_DEFINITION@

--- a/configure
+++ b/configure
@@ -27,6 +27,12 @@ for arg in "$@" ; do
 	esac
 done
 
+[ -z "$PREFIX" ] && PREFIX="${prefix:-/usr/local}"
+[ -z "$BINDIR" ] && BINDIR="${bindir:-$PREFIX/bin}"
+[ -z "$DATAROOTDIR" ] && DATAROOTDIR="${datarootdir:-$PREFIX/share}"
+[ -z "$MANDIR" ] && MANDIR="${mandir:-$DATAROOTDIR/man}"
+[ -z "$DOCDIR" ] && DOCDIR="${docdir:-$DATAROOTDIR/doc/html2text}"
+
 echo=echo
 
 rm -rf configure-tmp || exit 1;
@@ -262,6 +268,10 @@ for i in \
   EXPLICIT \
   LIBSTDCXX_INCLUDES \
   LIBSTDCXX_LIBS \
+  PREFIX \
+  BINDIR \
+  MANDIR \
+  DOCDIR \
   AUTO_PTR_BROKEN; \
 do cmd="$cmd -e \"s|@$i@|\$$i|g\""; done;
 for dir in $makedirs; do


### PR DESCRIPTION
Let the user set PREFIX, BINDIR, DATAROOTDIR, MANDIR, and DOCDIR at configure time either as variables (e.g. `PREFIX=/opt`) or flags (e.g. `--prefix=/opt`). This is more consistent with autotools.