### PR TITLE
Fix email on files copyright

### DIFF
--- a/iconvstream.cpp
+++ b/iconvstream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Fabian Groffen
+ * Copyright 2020-2022 Fabian Groffen <grobian@gentoo.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/iconvstream.h
+++ b/iconvstream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Fabian Groffen
+ * Copyright 2020-2022 Fabian Groffen <grobian@gentoo.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/istr.h
+++ b/istr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Fabian Groffen
+ * Copyright 2020 Fabian Groffen <grobian@gentoo.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 Fabian Groffen
+# Copyright 2020 Fabian Groffen <grobian@gentoo.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Add email in the copyright header:
  - iconvstream.cpp
  - iconvstream.h
  - istr.h
  - tests/runtest.sh

This pull request fixes #42 